### PR TITLE
User names with spaces

### DIFF
--- a/Turn/src/Game.cpp
+++ b/Turn/src/Game.cpp
@@ -47,6 +47,7 @@ string Game::InitializePlayerName() {
 		<< endl
 		<< "> ";
 
+	cin.ignore();
 	getline(cin, name); // Accepts full name
 	return name;
 }

--- a/Turn/src/Game.cpp
+++ b/Turn/src/Game.cpp
@@ -2,6 +2,7 @@
 #include <ctime>
 #include <fstream>
 #include <Windows.h>
+#include <string>
 
 #include "..\include\Game.h"
 #include "..\include\Common.h"
@@ -42,10 +43,11 @@ string Game::InitializePlayerName() {
 	ClearScreen();
 	string name;
 	cout << "What is your name?"
-		<< endl << endl
+		<< endl
+		<< endl
 		<< "> ";
 
-	cin >> name; // Change to full name
+	getline(cin, name); // Accepts full name
 	return name;
 }
 


### PR DESCRIPTION
Now uses string::getline() so usernames can have spaces.
Closes #4 