### PR TITLE
Gambling money check #5

### DIFF
--- a/Turn/include/Player.h
+++ b/Turn/include/Player.h
@@ -23,6 +23,7 @@ class Player : public Entity {
         void LoseCoins(int);
 
         void DisplayInventory();
+        int GetCoins();
 
     private:
         int GenericAttack();

--- a/Turn/src/Gambling.cpp
+++ b/Turn/src/Gambling.cpp
@@ -25,10 +25,10 @@ void Gambling::Gamble(Player *_Player){
     // check if the player has enough money to play 
     if (_Player->GetCoins() < CoinsDeduction) { 
         // the player does not have enough money 
-		cout << "You need at least " << CoinsDeduction << " coins to gamble." << endl << "0 - 9) Understood" << endl;
+        cout << "You need at least " << CoinsDeduction << " coins to gamble." << endl << "0 - 9) Understood" << endl;
 
-		// wait for user input to exit
-		input();
+        // wait for user input to exit
+        input();
         return; 
     } 
 

--- a/Turn/src/Gambling.cpp
+++ b/Turn/src/Gambling.cpp
@@ -21,6 +21,13 @@ void Gambling::Gamble(Player *_Player){
 
     // Generates random values for the local variables declared in the class.
     GenerateValues();
+
+    // check if the player has enough money to play 
+    if (_Player->GetCoins() < CoinsDeduction) { 
+        // the player does not have enough money 
+        return; 
+    } 
+
     // Player's die. Equal to a random number between 1 and 9.
     int Die=ReturnShakenDie();
     // Initialized to analyze user input.

--- a/Turn/src/Gambling.cpp
+++ b/Turn/src/Gambling.cpp
@@ -26,9 +26,7 @@ void Gambling::Gamble(Player *_Player){
     if (_Player->GetCoins() < CoinsDeduction) { 
         // the player does not have enough money 
         cout << "You need at least " << CoinsDeduction << " coins to gamble." << endl << "0 - 9) Understood" << endl;
-
-        // wait for user input to exit
-        input();
+	Sleep(SLEEP_MS);
         return; 
     } 
 

--- a/Turn/src/Gambling.cpp
+++ b/Turn/src/Gambling.cpp
@@ -25,7 +25,7 @@ void Gambling::Gamble(Player *_Player){
     // check if the player has enough money to play 
     if (_Player->GetCoins() < CoinsDeduction) { 
         // the player does not have enough money 
-        cout << "You need at least " << CoinsDeduction << " coins to gamble." << endl << "0 - 9) Understood" << endl;
+        cout << "You need at least " << CoinsDeduction << " coins to gamble." << endl;
 	Sleep(SLEEP_MS);
         return; 
     } 

--- a/Turn/src/Gambling.cpp
+++ b/Turn/src/Gambling.cpp
@@ -25,6 +25,10 @@ void Gambling::Gamble(Player *_Player){
     // check if the player has enough money to play 
     if (_Player->GetCoins() < CoinsDeduction) { 
         // the player does not have enough money 
+		cout << "You need at least " << CoinsDeduction << " coins to gamble." << endl << "0 - 9) Understood" << endl;
+
+		// wait for user input to exit
+		input();
         return; 
     } 
 

--- a/Turn/src/Player.cpp
+++ b/Turn/src/Player.cpp
@@ -257,6 +257,10 @@ void Player::DisplayInventory(){
     cout << "*---------------------------------*" << endl << endl;
 }
 
+int Player::GetCoins() { 
+    return coins; 
+} 
+
 int Player::GenericAttack(){
     int damage = ReturnDamage();
     DeductDamage(damage);


### PR DESCRIPTION
- Added public getCoins function to Player
- Added Player money compare check to CoinsDeduction under ```GenerateValues()```

This limits a player from entering the gambling view if they don't have enough money to be able to lose a round, but if they don't then when the option for gambling is chosen nothing happens; since it takes them to the gambling view then straight back. I think it feels a bit wrong.