### PR TITLE
Notify player when using non-existent item

### DIFF
--- a/Turn/src/Player.cpp
+++ b/Turn/src/Player.cpp
@@ -178,6 +178,8 @@ void Player::UseItem() {
 
 			break;
 		default:
+				cout<<"Item not present in the inventory!"<<endl;
+ 				Sleep(SLEEP_MS);
 			break;
 		}
 	}


### PR DESCRIPTION
When a player attempts to use an item that is not in their inventory, currently the game doesn't do anything at all.

Instead, there should be a message displayed that the item is not in the player's inventory, then call Sleep(SLEEP_MS) and redraw the screen.