### PR TITLE
Changes Entity::Attack to Entity::Action

### DIFF
--- a/Turn/include/Enemy.h
+++ b/Turn/include/Enemy.h
@@ -29,7 +29,7 @@ class Enemy : public Entity {
     public:
         Enemy();
 
-        int Attack();
+        int Action();
         void DisplayHUD();
 
 		std::vector<int> GetDrops();

--- a/Turn/include/Entity.h
+++ b/Turn/include/Entity.h
@@ -7,7 +7,7 @@ class Entity {
 public:
 	Entity();
 	std::string GetName();
-	virtual int Attack() = 0;
+	virtual int Action() = 0;
 	void TakeDamage(int);
 	bool IsDead();
 

--- a/Turn/include/Player.h
+++ b/Turn/include/Player.h
@@ -12,7 +12,7 @@ class Player : public Entity, public SoundMaker {
         void SaveGame();
 
         void SetPlayerData();
-        int Attack();
+        int Action();
 	void UseItem();
         void AddToInventory(std::vector<int>);
 	void AddStoreItemToInventory(int);

--- a/Turn/src/Enemy.cpp
+++ b/Turn/src/Enemy.cpp
@@ -20,7 +20,7 @@ Enemy::Enemy(){
     ExperienceAmount = 0;
 }
 
-int Enemy::Attack(){
+int Enemy::Action(){
     // Returns damage hit for the player. Uses random number to select enemy's move.
 
   int selector = rand()%9;

--- a/Turn/src/Game.cpp
+++ b/Turn/src/Game.cpp
@@ -335,8 +335,8 @@ void Game::Battle(){
         _Player->DisplayHUD(_Enemy);
         _Enemy->DisplayHUD();
 
-		int damagePlayer = _Player->Attack();
-        // Player's turn to attack Enemy.
+		int damagePlayer = _Player->Action();
+        // Player's turn to attack Enemy or choose other action.
 
 		if (damagePlayer != SKIP_TURN){
 			_Enemy->TakeDamage(damagePlayer);
@@ -368,7 +368,7 @@ void Game::Battle(){
 
         // Enemy's turn to attack player.
 		if (damagePlayer != SKIP_TURN)
-			_Player->TakeDamage(_Enemy->Attack());
+			_Player->TakeDamage(_Enemy->Action());
         Sleep(SLEEP_MS);
 
         // Executes when player's health is 0 or below.

--- a/Turn/src/Player.cpp
+++ b/Turn/src/Player.cpp
@@ -74,7 +74,7 @@ void Player::SetPlayerData(){
 	}
 }
 
-int Player::Attack(){
+int Player::Action(){
     // Returns the amount of attack points the player gives.
     // Also the main battle screen.
 


### PR DESCRIPTION
I changed the name of the Attack() method to Action().
The more general expression is supposed to improve readability. The name "Attack" implies the player is actually attacking although he might for example use an item, which causes a bit of confusion when trying to get to know the code. Therefore "Action" is more suitable.