### PR TITLE
Changed windows macro checks from `_WINDOWS` to `_WIN32`

### DIFF
--- a/Turn/include/Console.h
+++ b/Turn/include/Console.h
@@ -2,9 +2,9 @@
 #ifndef CONSOLE_H_INCLUDED
 #define CONSOLE_H_INCLUDED
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <Windows.h>
-#endif // _WINDOWS
+#endif // _WIN32
 
 class Console {
 public:
@@ -36,9 +36,9 @@ private:
 	// Copy constructor private and unimplemented for this singleton
 	Console(Console&) = delete;
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 	HANDLE m_hConsoleHandle;
-#endif // _WINDOWS
+#endif // _WIN32
 };
 
 #endif // CONSOLE_H_INCLUDED

--- a/Turn/include/Sound.h
+++ b/Turn/include/Sound.h
@@ -2,7 +2,7 @@
 #include <string>
 #include <vector>
 #include <utility>
-#ifndef _WINDOWS
+#ifndef _WIN32
 #include <mutex>
 #endif
 
@@ -37,7 +37,7 @@ public:
 
 	void PlaySoundFile(std::string const& filename);
 private:
-#ifndef _WINDOWS
+#ifndef _WIN32
 	std::mutex m_resourceMutex;
 #endif
 };

--- a/Turn/src/Console.cpp
+++ b/Turn/src/Console.cpp
@@ -1,5 +1,5 @@
 #include "../include/Console.h"
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <Windows.h>
 #include <conio.h>
 #else
@@ -7,24 +7,24 @@
 #include <stdio.h>
 #include <termios.h>
 #include <unistd.h>
-#endif // _WINDOWS
+#endif // _WIN32
 
 Console::Console() {
-#if defined(_WINDOWS)
+#ifdef _WIN32
 	m_hConsoleHandle = GetStdHandle(STD_OUTPUT_HANDLE);
 #endif
 }
 
 void Console::ClearScreen() {
-#ifdef _WINDOWS
+#ifdef _WIN32
 	system("cls");
 #else
 	system("clear");
-#endif // _WINDOWS
+#endif // _WIN32
 }
 
 char Console::GetChar() const {
-#ifdef _WINDOWS
+#ifdef _WIN32
 	return _getch();
 #else
 	// The following code attempts to manually reproduce the same behaviour as the
@@ -47,11 +47,11 @@ char Console::GetChar() const {
 
 	// Return the character that was read
 	return ch;
-#endif // _WINDOWS
+#endif // _WIN32
 }
 
 void Console::SetColour(EColour colour) {
-#ifdef _WINDOWS
+#ifdef _WIN32
 	enum WindowsAttributes
 	{
 		GREY = 7,
@@ -68,7 +68,7 @@ void Console::SetColour(EColour colour) {
 		DARK_GREY,		// EColour::DarkGrey
 		RED,			// EColour::Red
 		GREEN,			// EColour::Green
-		
+
 		RED_BACKGROUND,	// EColour::Background_Red
 		GREY_BACKGROUND,// EColour::Background_Grey
 	};
@@ -85,7 +85,7 @@ void Console::SetColour(EColour colour) {
 		"\033[0m\033[47m",	// EColour::Background_Grey
 	};
 	printf("%s", colourEscapeCodes[colour]);
-#endif // _WINDOWS
+#endif // _WIN32
 }
 
 Console& Console::GetInstance() {

--- a/Turn/src/Sound.cpp
+++ b/Turn/src/Sound.cpp
@@ -1,6 +1,6 @@
 #include "../include/Sound.h"
 
-#ifdef _WINDOWS
+#ifdef _WIN32
 #include <Windows.h>
 #include <MMSystem.h>
 #else
@@ -21,7 +21,7 @@
 PlatformSoundHelper SoundMaker::ms_SoundHelper;
 
 PlatformSoundHelper::PlatformSoundHelper() {
-#ifndef _WINDOWS
+#ifndef _WIN32
 	m_resourceMutex.lock();
 	SDL_Init(SDL_INIT_AUDIO);
 	Mix_OpenAudio(MIX_DEFAULT_FREQUENCY, MIX_DEFAULT_FORMAT, 2, 1024);
@@ -30,7 +30,7 @@ PlatformSoundHelper::PlatformSoundHelper() {
 }
 
 PlatformSoundHelper::~PlatformSoundHelper() {
-#ifndef _WINDOWS
+#ifndef _WIN32
 	m_resourceMutex.lock();
 	Mix_CloseAudio();
 	SDL_Quit();
@@ -39,7 +39,7 @@ PlatformSoundHelper::~PlatformSoundHelper() {
 }
 
 void PlatformSoundHelper::PlaySoundFile(std::string const& filename) {
-#ifdef _WINDOWS
+#ifdef _WIN32
 	PlaySound(filename.c_str(), NULL, SND_ASYNC);
 #else
 	// It would be possible to pre-cache the sounds for SDL_mixer, however instead
@@ -84,7 +84,8 @@ SoundMaker::SoundMaker():mInfo(),
 	attackFileNames.push_back(FileName + ATTACKFILENAME3);
 	attackFileNames.push_back(FileName + ATTACKFILENAMECRIT);
 }
-void SoundMaker::PlayPrimaryAttack(int damageDealt) 
+
+void SoundMaker::PlayPrimaryAttack(int damageDealt)
 {
 	//
 	// play attack sound based on damage delt. 0 is miss, top is
@@ -101,10 +102,12 @@ void SoundMaker::PlayPrimaryAttack(int damageDealt)
 	}
 	PlaySoundFile(attackFileNames[index]);
 }
+
 void SoundMaker::PlaySecondaryAttack(void)
 {
 	PlaySoundFile(altAttackFileName.c_str());
 }
+
 void SoundMaker::PlayHeal(void) {
 	PlaySoundFile(healFileName.c_str());
 }


### PR DESCRIPTION
This is the pull request mentioned by my issue #86. Replaces all macro checks from `_WINDOWS` to `_WIN32`.