### PR TITLE
Fix type warnings

### DIFF
--- a/src/Entity.cpp
+++ b/src/Entity.cpp
@@ -41,7 +41,7 @@ void Entity::TakeDamage(int damage) {
 void Entity::DisplayHealthBar(){
 	string healthBar = "        " + to_string(health);
 
-	for (int i = healthBar.length(); i < 20; i++)
+	for (size_t i = healthBar.length(); i < 20; i++)
 		healthBar += " ";
 
 	for (size_t i = 0; i < healthBar.length(); i++) {

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -493,7 +493,7 @@ int Player::Flee(){
 
 void Player::PrintInventoryItem(string preText, int itemCount, string postText)
 {
-	int countLength = 0, countCopy = itemCount;
+	size_t countLength = 0, countCopy = itemCount;
 	// Calculate length of itemCount
 	do {
 		countLength++;
@@ -501,7 +501,7 @@ void Player::PrintInventoryItem(string preText, int itemCount, string postText)
 	} while (countCopy);
 
 	// Subtract space used in line (4 spaces for front and back dash/space combos, length of start and end text, length of itemCount) from the total available width
-	int freeSpace = 35 - 4 - preText.length() - postText.length() - countLength;
+	size_t freeSpace = 35 - 4 - preText.length() - postText.length() - countLength;
 
 	// Create a string with the appropriate number of spaces to make the line meet required width
 	string spaces(freeSpace, ' ');
@@ -512,7 +512,7 @@ void Player::PrintInventoryItem(string preText, int itemCount, string postText)
 
 void Player::PrintXPBar(string preText1, int level, string postText1, string preText2, int experience, string postText2)
 {
-	int countLength = 0, levelCopy = level, experienceCopy = experience;
+	size_t countLength = 0, levelCopy = level, experienceCopy = experience;
 	// Calculate length of level and experience
 	do {
 		countLength++;
@@ -524,7 +524,7 @@ void Player::PrintXPBar(string preText1, int level, string postText1, string pre
 	} while (experienceCopy);
 
 	// Subtract space used in line (4 spaces for front and back dash/space combos, length of start and end text, length of level and experience) from the total available width
-	int freeSpace = 35 - 4 - preText1.length() - postText1.length() - preText2.length() - postText2.length()- countLength;
+	size_t freeSpace = 35 - 4 - preText1.length() - postText1.length() - preText2.length() - postText2.length() - countLength;
 
 	// Create a string with the appropriate number of spaces to make the line meet required width
 	string spaces(freeSpace, ' ');
@@ -538,9 +538,9 @@ void Player::PrintDivider(char edge, char filler, string centerText)
 	int countLength = 0;
 
 	// Subtract space used in line (2 spaces for edge symbols, length of centerText) from the total available width
-	int freeSpace = 35 - 2 - centerText.length();
-	int frontSpace = freeSpace/2;
-	int rearSpace = freeSpace - frontSpace;
+	size_t freeSpace = 35 - 2 - centerText.length();
+	size_t frontSpace = freeSpace/2;
+	size_t rearSpace = freeSpace - frontSpace;
 
 	// Create a the front and rear filler string
 	string frontFiller(frontSpace, filler);

--- a/src/StoreGreetings.cpp
+++ b/src/StoreGreetings.cpp
@@ -7,7 +7,7 @@
 std::string random_greeting() {
     std::random_device rand;
     std::default_random_engine rand_eng(rand());
-    std::uniform_int_distribution<int> uniform_dist(0, STORE_GREETINGS.size()-1);
+    std::uniform_int_distribution<int> uniform_dist(0, static_cast<int>(STORE_GREETINGS.size())-1);
     size_t index = uniform_dist(rand_eng);
     return STORE_GREETINGS[index];
 }


### PR DESCRIPTION
When you compile using Visual Studio, it will give some warnings about the variables type. I created this PR to solve this warnings and improve a casting to always working with these expected types.

I just changed the places where we are working with `size_t` (mainly strings), so wasn't needed to declare variables as integer.