### PR TITLE
Copy sounds folder when build the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,3 +28,9 @@ endif (WIN32)
 if (UNIX)
 	target_link_libraries(Turn SDL2 SDL2_mixer pthread)
 endif (UNIX)
+
+add_custom_command(
+	TARGET Turn PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+			${CMAKE_SOURCE_DIR}/sounds/ $<TARGET_FILE_DIR:Turn>/sounds/
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (UNIX)
 endif (UNIX)
 
 add_custom_command(
-	TARGET Turn PRE_BUILD
+    TARGET Turn PRE_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory
-			${CMAKE_SOURCE_DIR}/sounds/ $<TARGET_FILE_DIR:Turn>/sounds/
+	        ${CMAKE_SOURCE_DIR}/sounds/ $<TARGET_FILE_DIR:Turn>/sounds/
 )


### PR DESCRIPTION
When build the project, the `sounds` folder is copied for the same location of executable file. https://github.com/tagniam/Turn/issues/111