### PR TITLE
Add & Fix Basic Compiler Warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,12 @@ target_sources(Turn PRIVATE
 	${SOURCES}
 	)
 
+# Add warnings
+target_compile_options(Turn PRIVATE
+					   $<$<CXX_COMPILER_ID:MSVC>:/W3>
+					   $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
+					   )
+
 # Link WinMM required for PlaySound
 if (WIN32)
 	target_link_libraries(Turn winmm.lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ target_sources(Turn PRIVATE
 # Add warnings
 target_compile_options(Turn PRIVATE
 					   $<$<CXX_COMPILER_ID:MSVC>:/W3 /EHsc>
-					   $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
+					   $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>>:-Wall -Wextra -Wpedantic>
 					   )
 
 # Link WinMM required for PlaySound

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ target_sources(Turn PRIVATE
 
 # Add warnings
 target_compile_options(Turn PRIVATE
-					   $<$<CXX_COMPILER_ID:MSVC>:/W3>
+					   $<$<CXX_COMPILER_ID:MSVC>:/W3 /EHsc>
 					   $<$<CXX_COMPILER_ID:GNU,Clang>:-Wall -Wextra -Wpedantic>
 					   )
 

--- a/include/EnemyTypes/Cerberus.h
+++ b/include/EnemyTypes/Cerberus.h
@@ -10,12 +10,12 @@ public:
 	Cerberus();
 
 	EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // CERBERUS_H

--- a/include/EnemyTypes/Crab.h
+++ b/include/EnemyTypes/Crab.h
@@ -9,11 +9,11 @@ public:
     Crab();
 
     EnemyType GetType() override;
-    std::string GetIntro();
+    std::string GetIntro() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // CRAB_H

--- a/include/EnemyTypes/Demon.h
+++ b/include/EnemyTypes/Demon.h
@@ -9,11 +9,11 @@ public:
     Demon();
 
     EnemyType GetType() override;
-    std::string GetIntro();
+    std::string GetIntro() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // DEMON_H

--- a/include/EnemyTypes/Gargoyle.h
+++ b/include/EnemyTypes/Gargoyle.h
@@ -4,17 +4,17 @@
 #include "../Enemy.h"
 
 
-class Gargoyle : public Enemy 
+class Gargoyle : public Enemy
 {
 public:
 	Gargoyle();
 
     EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // GARGOYLE_H

--- a/include/EnemyTypes/GiantCrab.h
+++ b/include/EnemyTypes/GiantCrab.h
@@ -9,11 +9,11 @@ public:
     GiantCrab();
 
     EnemyType GetType() override;
-    std::string GetIntro();
+    std::string GetIntro() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // GIANTCRAB_H

--- a/include/EnemyTypes/GiantSquid.h
+++ b/include/EnemyTypes/GiantSquid.h
@@ -9,11 +9,11 @@ public:
     GiantSquid();
 
     EnemyType GetType() override;
-    std::string GetIntro();
+    std::string GetIntro() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // GIANTSQUID_H

--- a/include/EnemyTypes/Goblin.h
+++ b/include/EnemyTypes/Goblin.h
@@ -4,17 +4,17 @@
 #include "../Enemy.h"
 
 
-class Goblin : public Enemy 
+class Goblin : public Enemy
 {
 public:
 	Goblin();
 
     EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // GOBLIN_H

--- a/include/EnemyTypes/Gremlin.h
+++ b/include/EnemyTypes/Gremlin.h
@@ -4,17 +4,17 @@
 #include "../Enemy.h"
 
 
-class Gremlin : public Enemy 
+class Gremlin : public Enemy
 {
 public:
 	Gremlin();
 	EnemyType GetType() override;
-	std::string GetIntro();
-	
+	std::string GetIntro() override;
+
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // GREMLIN_H

--- a/include/EnemyTypes/Lich.h
+++ b/include/EnemyTypes/Lich.h
@@ -4,17 +4,17 @@
 #include "../Enemy.h"
 
 
-class Lich : public Enemy 
+class Lich : public Enemy
 {
 public:
     Lich();
 
     EnemyType GetType() override;
-    std::string GetIntro();
+    std::string GetIntro() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // LICH_H

--- a/include/EnemyTypes/Mimic.h
+++ b/include/EnemyTypes/Mimic.h
@@ -10,13 +10,13 @@ public:
     Mimic();
 
     EnemyType GetType() override;
-    std::string GetIntro();
+    std::string GetIntro() override;
 
 private:
 
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // MIMIC_H

--- a/include/EnemyTypes/Murloc.h
+++ b/include/EnemyTypes/Murloc.h
@@ -4,17 +4,17 @@
 #include "../Enemy.h"
 
 
-class Murloc : public Enemy 
+class Murloc : public Enemy
 {
 public:
     Murloc();
 
     EnemyType GetType() override;
-    std::string GetIntro();
+    std::string GetIntro() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // MURLOC_H

--- a/include/EnemyTypes/Putnafer.h
+++ b/include/EnemyTypes/Putnafer.h
@@ -4,17 +4,17 @@
 #include "../Enemy.h"
 
 
-class Putnafer : public Enemy 
+class Putnafer : public Enemy
 {
 public:
 	Putnafer();
 
     EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // PUTNAFER_H

--- a/include/EnemyTypes/RatKing.h
+++ b/include/EnemyTypes/RatKing.h
@@ -8,11 +8,11 @@ public:
     RatKing();
 
     EnemyType GetType() override;
-    std::string GetIntro();
+    std::string GetIntro() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 
     int amountOfRats_;
 };

--- a/include/EnemyTypes/Skeleton.h
+++ b/include/EnemyTypes/Skeleton.h
@@ -9,12 +9,12 @@ public:
 	Skeleton();
 
 	EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // SKELETON_H

--- a/include/EnemyTypes/Slimeball.h
+++ b/include/EnemyTypes/Slimeball.h
@@ -6,12 +6,12 @@
 class Slimeball : public Enemy {
 public:
     Slimeball();
-    std::string GetIntro();
+    std::string GetIntro() override;
     EnemyType GetType() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // SLIMEBALL_H

--- a/include/EnemyTypes/SmallDragon.h
+++ b/include/EnemyTypes/SmallDragon.h
@@ -9,12 +9,12 @@ public:
 	SmallDragon();
 
 	EnemyType GetType() override;
-	std::string GetIntro();
-	
+	std::string GetIntro() override;
+
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // SMALLDRAGON_H

--- a/include/EnemyTypes/SmallRat.h
+++ b/include/EnemyTypes/SmallRat.h
@@ -9,11 +9,11 @@ public:
 	SmallRat();
 
 	EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // SMALLRAT_H

--- a/include/EnemyTypes/Squid.h
+++ b/include/EnemyTypes/Squid.h
@@ -9,11 +9,11 @@ public:
     Squid();
 
     EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // SQUID_H

--- a/include/EnemyTypes/TimidGhost.h
+++ b/include/EnemyTypes/TimidGhost.h
@@ -10,12 +10,12 @@ public:
 	TimidGhost();
 
 	EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // TIMIDGHOST_H

--- a/include/EnemyTypes/Vampire.h
+++ b/include/EnemyTypes/Vampire.h
@@ -4,18 +4,18 @@
 #include "../Enemy.h"
 
 
-class Vampire : public Enemy 
+class Vampire : public Enemy
 {
 public:
 	Vampire();
 
     EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // VAMPIRE_H

--- a/include/EnemyTypes/Werewolf.h
+++ b/include/EnemyTypes/Werewolf.h
@@ -4,18 +4,18 @@
 #include "../Enemy.h"
 
 
-class Werewolf : public Enemy 
+class Werewolf : public Enemy
 {
 public:
 	Werewolf();
 
     EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // WEREWOLF_H

--- a/include/EnemyTypes/Zabra.h
+++ b/include/EnemyTypes/Zabra.h
@@ -4,18 +4,18 @@
 #include "../Enemy.h"
 
 
-class Zabra : public Enemy 
+class Zabra : public Enemy
 {
 public:
     Zabra();
 
     EnemyType GetType() override;
-    std::string GetIntro();
-    
+    std::string GetIntro() override;
+
 private:
-    int ReturnDamage();
-    int ReturnRiskAttackDamage();
-    int ReturnHealAmount();
+    int ReturnDamage() override;
+    int ReturnRiskAttackDamage() override;
+    int ReturnHealAmount() override;
 };
 
 #endif // ZBRA_H

--- a/include/EnemyTypes/Zombie.h
+++ b/include/EnemyTypes/Zombie.h
@@ -4,18 +4,18 @@
 #include "../Enemy.h"
 
 
-class Zombie : public Enemy 
+class Zombie : public Enemy
 {
 public:
 	Zombie();
 
     EnemyType GetType() override;
-	std::string GetIntro();
+	std::string GetIntro() override;
 
 private:
-	int ReturnDamage();
-	int ReturnRiskAttackDamage();
-	int ReturnHealAmount();
+	int ReturnDamage() override;
+	int ReturnRiskAttackDamage() override;
+	int ReturnHealAmount() override;
 };
 
 #endif // ZOMBIE_H

--- a/include/Game.h
+++ b/include/Game.h
@@ -42,9 +42,6 @@ class Game {
         // This object is not a pointer because it does not have a child class.
         Gambling _Gambling;
         Store _Store;
-        // the current level the player is at it this is different than what is in the _player object the player leveled up
-        int _Level;
-
 };
 
 #endif // GAME_H

--- a/src/Player.cpp
+++ b/src/Player.cpp
@@ -13,9 +13,9 @@ using namespace Common;
 
 #define SKIP_TURN -2
 
-Player::Player(void) 
+Player::Player(void)
 {
-	// Initialize default sounds, attackRange should be 
+	// Initialize default sounds, attackRange should be
 	// the result range of the ReturnDamage method in the child class
 	// Child constructor should call SetSoundInfo with appropriate stuff
 	SoundInfo info;
@@ -28,7 +28,7 @@ void Player::SaveGame(){
 	ofstream WriteData;
 	WriteData.open("data.txt");
 	if (WriteData.is_open()) {
-        	WriteData << player_type << endl 
+        	WriteData << player_type << endl
 			<< name << endl
             << gender << endl
 			<< level << endl
@@ -179,7 +179,7 @@ void Player::UseItem() {
 
 		// Displays the inventory.
 		DisplayInventory();
-		
+
 
 		// Gives player a list of moves to choose from.
 		cout << "Choose which item use:" << endl
@@ -394,7 +394,7 @@ int Player::GenericAttack(){
         cout << " attacks! He deals ";
     else
         cout << " attacks! She deals ";
-	ColourPrint(to_string(damage), Console::Red);
+    ColourPrint(to_string(damage), Console::Red);
     cout << " damage points!" << endl;
     if (damage>0) WeakenWeapon(2);
     return damage;
@@ -416,7 +416,7 @@ int Player::RiskAttack(){
 void Player::WeakenWeapon(int impact){
 	if (impact >= 0) weaponstrength -= impact + rand() % 5;
 	else weaponstrength -= rand() % 5;
-	
+
 	if (weaponstrength < 0)
 	{
 		weaponstrength = 0;
@@ -430,7 +430,7 @@ int Player::BowAndArrow(){
         cout << " shoots his bow! He deals ";
     else
         cout << " shoots her bow! She deals ";
-	Console::GetInstance().SetColour(Console::EColour::Red);
+    Console::GetInstance().SetColour(Console::EColour::Red);
     cout << damage;
 	Console::GetInstance().SetColour(Console::EColour::Default);
     cout << " damage points!" << endl;
@@ -536,8 +536,6 @@ void Player::PrintXPBar(string preText1, int level, string postText1, string pre
 
 void Player::PrintDivider(char edge, char filler, string centerText)
 {
-	int countLength = 0;
-
 	// Subtract space used in line (2 spaces for edge symbols, length of centerText) from the total available width
 	size_t freeSpace = 35 - 2 - centerText.length();
 	size_t frontSpace = freeSpace/2;
@@ -577,8 +575,8 @@ void Player::PrintClass() {           //print the player class in inventory form
 		backspace = freespace - 10;
 		break;
 	default:                       //default makes it warrior in accordance to character creation
-		std::cout << "Warrior";      
-		backspace = freespace - 10;  
+		std::cout << "Warrior";
+		backspace = freespace - 10;
 		break;
 	}
 	string rear(backspace, ' ');     //create blank string for filler

--- a/src/Sound.cpp
+++ b/src/Sound.cpp
@@ -73,8 +73,8 @@ SoundMaker::SoundMaker():mInfo(),
 						altAttackFileName("sounds/arrow.wav"),
 						healFileName("sounds/heal.wav"),
 						whetstoneFileName("sounds/whetstone.wav"),
-						potionFileName("sounds/potion.wav"),
-						bombFileName("sounds/bomb.wav")
+						bombFileName("sounds/bomb.wav"),
+						potionFileName("sounds/potion.wav")
 {
 	//
 	// Initialize file name array to names of files for attacks


### PR DESCRIPTION
Adds basic compiler warnings for the three major compilers (GCC, Clang, and MSVC) and fixes the warnings created by them.

Fixes issue #118 