### PR TITLE
Build on the command line on all OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,24 @@ Clone this project by running `git clone https://github.com/tagniam/Turn.git` in
 
 ### Building & Running
 #### Windows
+* In your terminal, make sure you are in the `Turn` directory.
+* For the right generator see [Visual Studio Generators](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html#visual-studio-generators)
+* To build with Visual Studio 16 2019 run the following commands:
+
+    ```shell
+    $ cmake -S . -B build -G "Visual Studio 15 2017"
+    $ cmake --build build
+    ```
+* Start the game by running `build\Turn.exe`.
+
+Alternative: Generate solution with CMake and build with Visual Studio
+
 * Run CMake on the `Turn` directory to generate a `.sln` solution file for Visual Studio. You can find a tutorial [here](https://cmake.org/runningcmake/).
+
+    ```shell
+    $ cmake -S . -B build -G "Visual Studio 15 2017"
+    ```
+
 * Run Visual Studio and open the generated `.sln` solution file.
 * Build the project by clicking `Build` -> `Build Solution`.
 * Start the game by clicking the green Run button in the toolbar.
@@ -28,10 +45,10 @@ Clone this project by running `git clone https://github.com/tagniam/Turn.git` in
 * Run the following commands:
 
     ```shell
-    $ cmake .
-    $ make
+    $ cmake -S . -B build
+    $ cmake --build build
     ```
-* Start the game by running `./Turn`.
+* Start the game by running `./build/Turn`.
 
 ### Playing
 See the game manual located in the [wiki](https://github.com/tagniam/Turn/wiki).


### PR DESCRIPTION
With cmake 3.13 release the `-S <source_dir>` and `-B <build_dir>`
parameter were added.

https://cmake.org/cmake/help/v3.13/release/3.13.html#command-line

With this change the need to create a build directory and then `cd` into
it is no more. Just `cmake -S . -B build` in the source directory and we
have an out of source build.

This also works with Visual Studio if the right generator expression is
passed to it.